### PR TITLE
AWS CodeDeploy 애플리케이션 수정

### DIFF
--- a/.github/workflows/CD-BE.yml
+++ b/.github/workflows/CD-BE.yml
@@ -41,7 +41,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Upload to S3
-        run: aws deploy push --application-name code-deploy --s3-location s3://rare-s3-bucket/server/build.zip --source .
+        run: aws deploy push --application-name code-deploy-2 --s3-location s3://rare-s3-bucket/server/build.zip --source .
 
       - name: Code Deploy
-        run: aws deploy create-deployment --application-name code-deploy --deployment-config-name CodeDeployDefault.OneAtATime --deployment-group-name dev --s3-location bucket=rare-s3-bucket,bundleType=zip,key=server/build.zip
+        run: aws deploy create-deployment --application-name code-deploy-2 --deployment-config-name CodeDeployDefault.OneAtATime --deployment-group-name dev --s3-location bucket=rare-s3-bucket,bundleType=zip,key=server/build.zip


### PR DESCRIPTION
- 같은 AWS code-deploy 를 사용하면 한 쪽에서 배포를 했을 때(예:Client) 다른 쪽(예:Server) 의 디렉토리가 사라지는 현상이 발생했다.
- 그 현상을 고치고자 따로 code-deploy 를 만들고, CD-BE 파일을 수정한다.
