### PR TITLE
좋아요 순으로 Content 정렬(내림차순)

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -12,7 +12,7 @@ Hamil, Han
 
 == Post
 
-=== 메인 페이지 조회 (최신순으로 정렬)
+=== 메인 페이지 조회 (생성시간 순으로 정렬)
 
 ==== Request
 
@@ -80,7 +80,7 @@ include::{snippets}/post-controller-test/delete_post/http-response.adoc[]
 
 include::{snippets}/post-controller-test/delete_post/response-fields.adoc[]
 
-=== 좋아요 수를 기준으로 내림차순 출력 API
+=== 메인 페이지 조회 (좋아요 순으로 정렬)
 
 ==== Request Parameter
 

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -84,16 +84,16 @@ include::{snippets}/post-controller-test/delete_post/response-fields.adoc[]
 
 ==== Request Parameter
 
-include::{snippets}/post-controller-test/find_posts_by_likes_in_descending_order/request-parameters.adoc[]
+include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/request-parameters.adoc[]
 
 ==== Request
 
-include::{snippets}/post-controller-test/find_posts_by_likes_in_descending_order/http-request.adoc[]
+include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/http-request.adoc[]
 
 ==== Response
 
-include::{snippets}/post-controller-test/find_posts_by_likes_in_descending_order/http-response.adoc[]
+include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/http-response.adoc[]
 
 ==== Response Fields
 
-include::{snippets}/post-controller-test/find_posts_by_likes_in_descending_order/response-fields.adoc[]
+include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/response-fields.adoc[]

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -61,3 +61,21 @@ include::{snippets}/post-controller-test/delete_post_spring_rest_docs/http-respo
 ==== Response Fields
 
 include::{snippets}/post-controller-test/delete_post_spring_rest_docs/response-fields.adoc[]
+
+=== 좋아요 수를 기준으로 내림차순 출력 API
+
+==== Request Parameter
+
+include::{snippets}/post-controller-test/find_posts_by_likes_in_descending_order/request-parameters.adoc[]
+
+==== Request
+
+include::{snippets}/post-controller-test/find_posts_by_likes_in_descending_order/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/post-controller-test/find_posts_by_likes_in_descending_order/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/post-controller-test/find_posts_by_likes_in_descending_order/response-fields.adoc[]

--- a/src/main/java/com/codesquad/rare/domain/post/PostController.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostController.java
@@ -48,11 +48,11 @@ public class PostController {
     return OK(true);
   }
 
-  // 포스트를 좋아요 수를 기준으로 내림차순 출력
+  // 좋아요 순으로 내림차순 정렬
   @GetMapping("/likes")
   public ApiResult<List<Post>> findAllByLikesInDescendingOrder(
-      @RequestParam(value = "page", required = false, defaultValue = DEFAULT_PAGE) Integer page,
-      @RequestParam(value = "size", required = false, defaultValue = DEFAULT_SIZE) Integer size) {
+      @RequestParam(value = "page", required = false, defaultValue = DEFAULT_PAGE) int page,
+      @RequestParam(value = "size", required = false, defaultValue = DEFAULT_SIZE) int size) {
     return OK(postService.findAllByLikesInDescendingOrder(page, size));
   }
 }

--- a/src/main/java/com/codesquad/rare/domain/post/PostController.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
   private final PostService postService;
+  private static final String DEFAULT_PAGE = "0";
+  private static final String DEFAULT_SIZE = "20";
 
   @GetMapping
   public ApiResult<List<Post>> main() {
@@ -50,8 +52,10 @@ public class PostController {
   }
 
   // 포스트를 좋아요 수를 기준으로 내림차순 출력
-  @GetMapping("/lists/liked")
-  public List<Post> findPostsByLikesInDescendingOrder(@RequestParam Integer page, Integer size) {
-    return postService.findPostsByLikesInDescendingOrder(page, size);
+  @GetMapping("/likes")
+  public ApiResult<List<Post>> findPostsByLikesInDescendingOrder(
+      @RequestParam(value = "page", required = false, defaultValue = DEFAULT_PAGE) Integer page,
+      @RequestParam(value = "size", required = false, defaultValue = DEFAULT_SIZE) Integer size) {
+    return OK(postService.findPostsByLikesInDescendingOrder(page, size));
   }
 }

--- a/src/main/java/com/codesquad/rare/domain/post/PostController.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -46,5 +47,11 @@ public class PostController {
   public ApiResult delete(@PathVariable("id") Long postId) {
     postService.delete(postId);
     return OK("true");
+  }
+
+  // 포스트를 좋아요 수를 기준으로 내림차순 출력
+  @GetMapping("/lists/liked")
+  public List<Post> findPostsByLikesInDescendingOrder(@RequestParam Integer page, Integer size) {
+    return postService.findPostsByLikesInDescendingOrder(page, size);
   }
 }

--- a/src/main/java/com/codesquad/rare/domain/post/PostController.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostController.java
@@ -53,9 +53,9 @@ public class PostController {
 
   // 포스트를 좋아요 수를 기준으로 내림차순 출력
   @GetMapping("/likes")
-  public ApiResult<List<Post>> findPostsByLikesInDescendingOrder(
+  public ApiResult<List<Post>> findAllByLikesInDescendingOrder(
       @RequestParam(value = "page", required = false, defaultValue = DEFAULT_PAGE) Integer page,
       @RequestParam(value = "size", required = false, defaultValue = DEFAULT_SIZE) Integer size) {
-    return OK(postService.findPostsByLikesInDescendingOrder(page, size));
+    return OK(postService.findAllByLikesInDescendingOrder(page, size));
   }
 }

--- a/src/main/java/com/codesquad/rare/domain/post/PostService.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostService.java
@@ -43,8 +43,8 @@ public class PostService {
     return post;
   }
 
-  public List<Post> findPostsByLikesInDescendingOrder(Integer page, Integer size) {
-    PageRequest pageRequest = PageRequest.of(page, size, Sort.by("likes").descending());
+  public List<Post> findAllByLikesInDescendingOrder(Integer page, Integer size) {
+    PageRequest pageRequest = PageRequest.of(page, size, Sort.by("likes").descending(), );
     return postRepository.findAll(pageRequest).getContent();
   }
 }

--- a/src/main/java/com/codesquad/rare/domain/post/PostService.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostService.java
@@ -4,6 +4,8 @@ import com.codesquad.rare.error.exeception.NotFoundException;
 import java.util.List;
 import javax.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,5 +41,10 @@ public class PostService {
         .orElseThrow(() -> new NotFoundException(Post.class, postId));
     postRepository.delete(post);
     return post;
+  }
+
+  public List<Post> findPostsByLikesInDescendingOrder(Integer page, Integer size) {
+    PageRequest pageRequest = PageRequest.of(page, size, Sort.by("likes").descending());
+    return postRepository.findAll(pageRequest).getContent();
   }
 }

--- a/src/main/java/com/codesquad/rare/domain/post/PostService.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostService.java
@@ -51,7 +51,7 @@ public class PostService {
   }
 
   public List<Post> findAllByLikesInDescendingOrder(Integer page, Integer size) {
-    PageRequest pageRequest = PageRequest.of(page, size, Sort.by("likes").descending(), );
+    PageRequest pageRequest = PageRequest.of(page, size, Sort.by("likes").descending());
     return postRepository.findAll(pageRequest).getContent();
   }
 }

--- a/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
+++ b/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
@@ -86,7 +86,7 @@ class PostControllerTest {
     }
   }
 
-  @DisplayName("메인 페이지 조회 (생성 시간 기준 오름차순 정렬")
+  @DisplayName("메인 페이지 조회 (생성 시간 기준 내름차순 정렬)")
   @Test
   void find_all_posts() throws Exception {
 
@@ -285,7 +285,7 @@ class PostControllerTest {
             )));
   }
 
-  @DisplayName("포스트를 좋아요 수를 기준으로 내림차순 출력")
+  @DisplayName("메인 페이지 조회 (좋아요 순으로 내름차순 정렬)")
   @Test
   public void find_all_by_likes_in_descending_order() throws Exception {
     //given

--- a/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
+++ b/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
@@ -17,7 +17,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.subsecti
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -288,7 +287,7 @@ class PostControllerTest {
 
   @DisplayName("포스트를 좋아요 수를 기준으로 내림차순 출력")
   @Test
-  public void find_posts_by_likes_in_descending_order() throws Exception {
+  public void find_all_by_likes_in_descending_order() throws Exception {
     //given
     Random random = new Random();
 
@@ -338,7 +337,8 @@ class PostControllerTest {
     Integer size = 20;
 
     List<Post> posts = Arrays.asList(post3, post2, post1);
-    given(postService.findPostsByLikesInDescendingOrder(page, size)).willReturn(posts);
+    log.info("posts : {}", posts);
+    given(postController.findAllByLikesInDescendingOrder(page, size)).willReturn(OK(posts));
 
     //when
     MultiValueMap<String, String> map = new LinkedMultiValueMap<>();


### PR DESCRIPTION
- Paging 을 사용하여 간단하게 좋아요 순으로 목록을 출력할 수 있도록 만들었습니다

- 만들다가 든 생각은 트렌딩은 지금 현 시점의 트렌드한 게시물(좋아요 수가 많은 게시물)을 보여줘야 할텐데요.
- 지금 로직으로는 가장 오래된 포스트여도 좋아요 수가 많다면 트렌딩에 뜨게끔 해둔 것입니다.
- 기간같은 걸로 범위를 지정해준다음에 그 목록 속에서 좋아요 순으로 정렬하는 게 어떨까 하고 개인적으로 생각했습니다.
- 같이 이야기해보면 좋을 것 같습니다 