### PR TITLE
Feature/issue 058

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -16,15 +16,33 @@ Hamil, Han
 
 ==== Request
 
-include::{snippets}/post-controller-test/find_all_posts/http-request.adoc[]
+include::{snippets}/post-controller-test/find_all_in_latest_order/http-request.adoc[]
 
 ==== Response
 
-include::{snippets}/post-controller-test/find_all_posts/http-response.adoc[]
+include::{snippets}/post-controller-test/find_all_in_latest_order/http-response.adoc[]
 
 ==== Response Fields
 
-include::{snippets}/post-controller-test/find_all_posts/response-fields.adoc[]
+include::{snippets}/post-controller-test/find_all_in_latest_order/response-fields.adoc[]
+
+=== 메인 페이지 조회 (좋아요 순으로 정렬)
+
+==== Request Parameter
+
+include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/request-parameters.adoc[]
+
+==== Request
+
+include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/response-fields.adoc[]
 
 === 포스트 조회
 
@@ -79,21 +97,3 @@ include::{snippets}/post-controller-test/delete_post/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/post-controller-test/delete_post/response-fields.adoc[]
-
-=== 메인 페이지 조회 (좋아요 순으로 정렬)
-
-==== Request Parameter
-
-include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/request-parameters.adoc[]
-
-==== Request
-
-include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/http-request.adoc[]
-
-==== Response
-
-include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/http-response.adoc[]
-
-==== Response Fields
-
-include::{snippets}/post-controller-test/find_all_by_likes_in_descending_order/response-fields.adoc[]

--- a/src/main/java/com/codesquad/rare/domain/post/Post.java
+++ b/src/main/java/com/codesquad/rare/domain/post/Post.java
@@ -2,6 +2,7 @@ package com.codesquad.rare.domain.post;
 
 import com.codesquad.rare.domain.account.Account;
 import com.codesquad.rare.domain.post.request.PostCreateRequest;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
@@ -25,6 +26,7 @@ import lombok.NoArgsConstructor;
 @JsonPropertyOrder({
     "id",
     "title",
+    "subTitle",
     "content",
     "thumbnail",
     "author",
@@ -44,6 +46,8 @@ public class Post {
   @Column(length = 100)
   private String title;
 
+  private String subTitle;
+
   @Lob
   private String content;
 
@@ -60,11 +64,15 @@ public class Post {
 
   private String tags;
 
+  @JsonIgnore
+  private Boolean isPublic;
+
   private LocalDateTime createdAt;
 
   public static Post toEntity(PostCreateRequest postCreateRequest, Account author) {
     return Post.builder()
         .title(postCreateRequest.getTitle())
+        .subTitle(postCreateRequest.getSubTitle())
         .content(postCreateRequest.getContent())
         .thumbnail(postCreateRequest.getThumbnail())
         .author(author)
@@ -72,6 +80,7 @@ public class Post {
         .likes(0)
         .tags(postCreateRequest.getTags())
         .createdAt(LocalDateTime.now())
+        .isPublic(postCreateRequest.getIsPublic())
         .build();
   }
 }

--- a/src/main/java/com/codesquad/rare/domain/post/PostController.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostController.java
@@ -6,6 +6,7 @@ import com.codesquad.rare.common.api.ApiResult;
 import com.codesquad.rare.domain.post.request.PostCreateRequest;
 import com.codesquad.rare.domain.post.response.PostCreateResponse;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,9 +28,12 @@ public class PostController {
   private static final String DEFAULT_PAGE = "0";
   private static final String DEFAULT_SIZE = "20";
 
-  @GetMapping
-  public ApiResult<List<Post>> findAllInLatestOrder() {
-    return OK(postService.findAllAndOrderByCreatedAtDesc());
+  //생성시간 순으로 내림차순 정렬
+  @GetMapping("createdAt")
+  public ApiResult<List<Post>> findAllInLatestOrder(
+      @RequestParam(value = "page", required = false, defaultValue = DEFAULT_PAGE) int page,
+      @RequestParam(value = "size", required = false, defaultValue = DEFAULT_SIZE) int size) {
+    return OK(postService.findAllAndOrderByCreatedAtDesc(page, size));
   }
 
   @GetMapping("{id}")
@@ -38,21 +42,14 @@ public class PostController {
   }
 
   @PostMapping
-  public ApiResult<PostCreateResponse> create(@RequestBody PostCreateRequest postCreateRequest) {
+  public ApiResult<PostCreateResponse> create(
+      @Valid @RequestBody PostCreateRequest postCreateRequest) {
     return OK(postService.save(postCreateRequest));
   }
 
-  @DeleteMapping("/{id}")
+  @DeleteMapping("{id}")
   public ApiResult delete(@PathVariable("id") Long postId) {
     postService.delete(postId);
     return OK(true);
-  }
-
-  // 좋아요 순으로 내림차순 정렬
-  @GetMapping("/likes")
-  public ApiResult<List<Post>> findAllByLikesInDescendingOrder(
-      @RequestParam(value = "page", required = false, defaultValue = DEFAULT_PAGE) int page,
-      @RequestParam(value = "size", required = false, defaultValue = DEFAULT_SIZE) int size) {
-    return OK(postService.findAllByLikesInDescendingOrder(page, size));
   }
 }

--- a/src/main/java/com/codesquad/rare/domain/post/PostController.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostController.java
@@ -36,6 +36,14 @@ public class PostController {
     return OK(postService.findAllAndOrderByCreatedAtDesc(page, size));
   }
 
+  // 좋아요 순으로 내림차순 정렬
+  @GetMapping("likes")
+  public ApiResult<List<Post>> findAllByLikesInDescendingOrder(
+      @RequestParam(value = "page", required = false, defaultValue = DEFAULT_PAGE) int page,
+      @RequestParam(value = "size", required = false, defaultValue = DEFAULT_SIZE) int size) {
+    return OK(postService.findAllByLikesInDescendingOrder(page, size));
+  }
+
   @GetMapping("{id}")
   public ApiResult<Post> findById(@PathVariable(value = "id") Long postId) {
     return OK(postService.findById(postId));

--- a/src/main/java/com/codesquad/rare/domain/post/PostDataRunner.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostDataRunner.java
@@ -73,6 +73,7 @@ public class PostDataRunner implements ApplicationRunner {
     Random random = new Random();
     LocalDateTime localDateTime = LocalDateTime.now();
     List<Post> postList = new ArrayList<>();
+    boolean[] rando = new boolean[]{true, false};
     int length = luda.length;
 
     Account won = Account.builder()
@@ -82,9 +83,10 @@ public class PostDataRunner implements ApplicationRunner {
 
     saveAccount(won);
 
-    for (int i = 1; i <= 10; i++) {
+    for (int i = 1; i <= 99; i++) {
       Post post = Post.builder()
-          .title(i + "번째 포스팅 입니다")
+          .title(i + "번째 제목 입니다")
+          .subTitle(i + "번째 부제목 입니다")
           .content("이런 저런 내용이 담겨있어요")
           .author(won)
           .likes(random.nextInt(99))
@@ -92,6 +94,7 @@ public class PostDataRunner implements ApplicationRunner {
           .views(random.nextInt(999))
           .thumbnail(luda[random.nextInt(length)])
           .createdAt(localDateTime.plusDays(random.nextInt(10 - 5 + 1) + 5))
+          .isPublic(rando[random.nextInt(2)])
           .build();
 
       postList.add(post);

--- a/src/main/java/com/codesquad/rare/domain/post/PostRepository.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostRepository.java
@@ -1,9 +1,10 @@
 package com.codesquad.rare.domain.post;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-  List<Post> findAllByOrderByCreatedAtDesc();
+  Page<Post> findAllByIsPublicTrue(Pageable pageable);
 }

--- a/src/main/java/com/codesquad/rare/domain/post/PostService.java
+++ b/src/main/java/com/codesquad/rare/domain/post/PostService.java
@@ -23,8 +23,9 @@ public class PostService {
 
   private final AccountRepository accountRepository;
 
-  public List<Post> findAllAndOrderByCreatedAtDesc() {
-    return postRepository.findAllByOrderByCreatedAtDesc();
+  public List<Post> findAllAndOrderByCreatedAtDesc(int page, int size) {
+    PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt").descending());
+    return postRepository.findAllByIsPublicTrue(pageRequest).getContent();
   }
 
   public Post findById(Long postId) {
@@ -50,8 +51,8 @@ public class PostService {
     return post;
   }
 
-  public List<Post> findAllByLikesInDescendingOrder(Integer page, Integer size) {
+  public List<Post> findAllByLikesInDescendingOrder(int page, int size) {
     PageRequest pageRequest = PageRequest.of(page, size, Sort.by("likes").descending());
-    return postRepository.findAll(pageRequest).getContent();
+    return postRepository.findAllByIsPublicTrue(pageRequest).getContent();
   }
 }

--- a/src/main/java/com/codesquad/rare/domain/post/request/PostCreateRequest.java
+++ b/src/main/java/com/codesquad/rare/domain/post/request/PostCreateRequest.java
@@ -1,26 +1,34 @@
 package com.codesquad.rare.domain.post.request;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@ToString
 public class PostCreateRequest {
 
+  @NotBlank(message = "제목을 반드시 입력해주세요")
   private String title;
+
+  @NotBlank(message = "부제목을 반드시 입력해주세요")
+  private String subTitle;
 
   private String content;
 
   private String thumbnail;
 
+  @NotNull(message = "작성자의 ID는 반드시 입력해주세요")
   private Long authorId;
 
   private String tags;
+
+  @NotNull(message = "공개 여부를 반드시 입력해주세요")
+  private Boolean isPublic;
 }

--- a/src/main/java/com/codesquad/rare/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codesquad/rare/error/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -38,6 +39,13 @@ public class GlobalExceptionHandler {
 
     log.error("Unexpected service exception occurred: {}", e.getMessage(), e);
     return newResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  //@Validation Exception handler
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<?> handleConstraintViolationException(MethodArgumentNotValidException e) {
+    log.error("MethodArgumentNotValidException occurred: {}", e.getMessage(), e);
+    return newResponse(e, HttpStatus.BAD_REQUEST);
   }
 
 }

--- a/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
+++ b/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
@@ -47,8 +47,6 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
@@ -65,9 +63,6 @@ class PostControllerTest {
 
   @MockBean
   PostController postController;
-
-  @MockBean
-  PostRepository postRepository;
 
   Random random = new Random();
 
@@ -126,26 +121,23 @@ class PostControllerTest {
 
   @DisplayName("메인 페이지 조회 (생성 시간 기준 내림차순 정렬)")
   @Test
-  void find_all_posts() throws Exception {
+  void find_all_in_latest_order() throws Exception {
 
     //given
     Post post1 = getPost(random, won, 1L, "1번째 포스팅 입니다");
     Post post2 = getPost(random, won, 2L, "2번째 포스팅 입니다");
 
-    Integer page = 0;
-    Integer size = 20;
+    int page = 0;
+    int size = 20;
 
     List<Post> posts = Arrays.asList(post1, post2);
     given(postController.findAllInLatestOrder(page, size)).willReturn(OK(posts));
 
-    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-    map.add("page", page.toString());
-    map.add("size", size.toString());
-
     //when
     ResultActions result = mockMvc.perform(get("/posts/createdAt")
         .contentType(MediaType.APPLICATION_JSON)
-        .queryParams(map));
+        .param("page", String.valueOf(page))
+        .param("size", String.valueOf(size)));
 
     //then
     result.andExpect(status().isOk())
@@ -171,7 +163,8 @@ class PostControllerTest {
                 fieldWithPath("response.[].views").description("포스트 조회").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.[].likes").description("포스트 좋아요 수").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.[].tags").description("포스트 태그").type(JsonFieldType.STRING),
-                fieldWithPath("response.[].createdAt").description("포스트 생성 시간").type(JsonFieldType.STRING)
+                fieldWithPath("response.[].createdAt").description("포스트 생성 시간")
+                    .type(JsonFieldType.STRING)
             )));
   }
 
@@ -183,21 +176,17 @@ class PostControllerTest {
     Post post2 = getPost(random, won, 2L, "2번째 포스팅 입니다");
     Post post3 = getPost(random, won, 3L, "3번째 포스팅 입니다");
 
-    Integer page = 0;
-    Integer size = 20;
+    int page = 0;
+    int size = 20;
 
     List<Post> posts = Arrays.asList(post3, post2, post1);
     given(postController.findAllByLikesInDescendingOrder(page, size)).willReturn(OK(posts));
 
     //when
-    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-    map.add("page", page.toString());
-    map.add("size", size.toString());
-
     ResultActions result = mockMvc.perform(get("/posts/likes")
         .contentType(MediaType.APPLICATION_JSON)
-        .accept(MediaType.APPLICATION_JSON)
-        .queryParams(map));
+        .param("page", String.valueOf(page))
+        .param("size", String.valueOf(size)));
 
     //then
     result.andExpect(status().isOk())
@@ -215,23 +204,16 @@ class PostControllerTest {
 
                 subsectionWithPath("response").description("응답"),
 
-                fieldWithPath("response.[].id").description("포스트 ID 번호(고유한 값)")
-                    .type(JsonFieldType.NUMBER),
+                fieldWithPath("response.[].id").description("포스트 ID 번호(고유한 값)").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.[].title").description("포스트 제목").type(JsonFieldType.STRING),
-                fieldWithPath("response.[].subTitle").description("포스트 보조 제목")
-                    .type(JsonFieldType.STRING),
-                fieldWithPath("response.[].content").description("포스트 내용")
-                    .type(JsonFieldType.STRING),
-                fieldWithPath("response.[].thumbnail").description("포스트 썸네일")
-                    .type(JsonFieldType.STRING),
-                fieldWithPath("response.[].author").description("포스트 저자")
-                    .type(JsonFieldType.OBJECT),
+                fieldWithPath("response.[].subTitle").description("포스트 보조 제목").type(JsonFieldType.STRING),
+                fieldWithPath("response.[].content").description("포스트 내용").type(JsonFieldType.STRING),
+                fieldWithPath("response.[].thumbnail").description("포스트 썸네일").type(JsonFieldType.STRING),
+                fieldWithPath("response.[].author").description("포스트 저자").type(JsonFieldType.OBJECT),
                 fieldWithPath("response.[].views").description("포스트 조회").type(JsonFieldType.NUMBER),
-                fieldWithPath("response.[].likes").description("포스트 좋아요 수")
-                    .type(JsonFieldType.NUMBER),
+                fieldWithPath("response.[].likes").description("포스트 좋아요 수").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.[].tags").description("포스트 태그").type(JsonFieldType.STRING),
-                fieldWithPath("response.[].createdAt").description("포스트 생성 시간")
-                    .type(JsonFieldType.STRING)
+                fieldWithPath("response.[].createdAt").description("포스트 생성 시간").type(JsonFieldType.STRING)
             )));
   }
 
@@ -263,15 +245,19 @@ class PostControllerTest {
                     fieldWithPath("title").description("포스트 제목부 (필수)").type(JsonFieldType.STRING),
                     fieldWithPath("subTitle").description("포스트 제목 (필수)").type(JsonFieldType.STRING),
                     fieldWithPath("content").description("포스트 내용").type(JsonFieldType.STRING),
-                    fieldWithPath("thumbnail").description("포스트 썸네일 이미지").type(JsonFieldType.STRING),
-                    fieldWithPath("authorId").description("포스트 작성자 ID (필수)").type(JsonFieldType.NUMBER),
+                    fieldWithPath("thumbnail").description("포스트 썸네일 이미지")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("authorId").description("포스트 작성자 ID (필수)")
+                        .type(JsonFieldType.NUMBER),
                     fieldWithPath("tags").description("포스트 태그").type(JsonFieldType.STRING),
-                    fieldWithPath("isPublic").description("포스트 공개 여부 (필수)").type(JsonFieldType.BOOLEAN)
+                    fieldWithPath("isPublic").description("포스트 공개 여부 (필수)")
+                        .type(JsonFieldType.BOOLEAN)
                 ),
                 responseFields(
                     fieldWithPath("success").description("성공 유무").type(JsonFieldType.BOOLEAN),
                     fieldWithPath("response").description("응답").type(JsonFieldType.OBJECT),
-                    fieldWithPath("response.postId").description("생성된 포스트 ID").type(JsonFieldType.NUMBER),
+                    fieldWithPath("response.postId").description("생성된 포스트 ID")
+                        .type(JsonFieldType.NUMBER),
                     fieldWithPath("error").description("에러 메세지").type(JsonFieldType.NULL)
                 )
             ));
@@ -333,15 +319,18 @@ class PostControllerTest {
                 fieldWithPath("success").description("성공 여부").type(JsonFieldType.BOOLEAN),
                 fieldWithPath("error").description("에러 메세지").type(JsonFieldType.NULL),
                 subsectionWithPath("response").description("응답"),
-                fieldWithPath("response.id").description("포스트 ID 번호(고유한 값)").type(JsonFieldType.NUMBER),
+                fieldWithPath("response.id").description("포스트 ID 번호(고유한 값)")
+                    .type(JsonFieldType.NUMBER),
                 fieldWithPath("response.title").description("포스트 제목").type(JsonFieldType.STRING),
                 fieldWithPath("response.content").description("포스트 내용").type(JsonFieldType.STRING),
-                fieldWithPath("response.thumbnail").description("포스트 썸네일").type(JsonFieldType.STRING),
+                fieldWithPath("response.thumbnail").description("포스트 썸네일")
+                    .type(JsonFieldType.STRING),
                 fieldWithPath("response.author").description("포스트 저자").type(JsonFieldType.OBJECT),
                 fieldWithPath("response.views").description("포스트 조회").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.likes").description("포스트 좋아요 수").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.tags").description("포스트 태그").type(JsonFieldType.STRING),
-                fieldWithPath("response.createdAt").description("포스트 생성 시간").type(JsonFieldType.STRING)
+                fieldWithPath("response.createdAt").description("포스트 생성 시간")
+                    .type(JsonFieldType.STRING)
             )));
   }
 }

--- a/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
+++ b/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
@@ -58,7 +58,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @AutoConfigureRestDocs
 class PostControllerTest {
 
-  private final Logger log = LoggerFactory.getLogger(PostControllerTest.class);
+  final Logger log = LoggerFactory.getLogger(PostControllerTest.class);
 
   @Autowired
   MockMvc mockMvc;
@@ -68,6 +68,15 @@ class PostControllerTest {
 
   @MockBean
   PostRepository postRepository;
+
+  Random random = new Random();
+
+  Account won = Account.builder()
+      .id(1L)
+      .name("won")
+      .avatarUrl("https://img.hankyung.com/photo/201906/03.19979855.1.jpg")
+      .build();
+
 
   @BeforeEach
   void set_up(WebApplicationContext webApplicationContext,
@@ -86,49 +95,57 @@ class PostControllerTest {
     }
   }
 
-  @DisplayName("메인 페이지 조회 (생성 시간 기준 내름차순 정렬)")
+  private PostCreateRequest getPostCreateRequest() {
+    return PostCreateRequest.builder()
+        .title("타이틀입니다일 (필수)")
+        .subTitle("보조 타이틀 입니다(필수)")
+        .content("내용")
+        .authorId(1L)
+        .tags("1번")
+        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
+        .isPublic(true)
+        .build();
+  }
+
+  private Post getPost(Random random, Account won, long id, String title) {
+    return Post.builder()
+        .id(id)
+        .title(id + title)
+        .subTitle("보조 제목")
+        .content("이런 저런 내용이 담겨있어요")
+        .author(won)
+        .likes(random.nextInt(99))
+        .tags("태")
+        .views(random.nextInt(999))
+        .createdAt(LocalDateTime.now())
+        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
+        .isPublic(true)
+        .build();
+  }
+
+
+  @DisplayName("메인 페이지 조회 (생성 시간 기준 내림차순 정렬)")
   @Test
   void find_all_posts() throws Exception {
 
     //given
-    Random random = new Random();
+    Post post1 = getPost(random, won, 1L, "1번째 포스팅 입니다");
+    Post post2 = getPost(random, won, 2L, "2번째 포스팅 입니다");
 
-    Account won = Account.builder()
-        .id(1L)
-        .name("won")
-        .avatarUrl("https://img.hankyung.com/photo/201906/03.19979855.1.jpg")
-        .build();
-
-    Post post1 = Post.builder()
-        .id(1L)
-        .title("1번째 포스팅 입니다")
-        .content("이런 저런 내용이 담겨있어요")
-        .author(won)
-        .likes(random.nextInt(99))
-        .tags("1번")
-        .views(random.nextInt(999))
-        .createdAt(LocalDateTime.now())
-        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
-        .build();
-
-    Post post2 = Post.builder()
-        .id(2L)
-        .title("2번째 포스팅 입니다")
-        .content("이런 저런 내용이 담겨있어요")
-        .author(won)
-        .likes(random.nextInt(99))
-        .tags("2번")
-        .views(random.nextInt(999))
-        .createdAt(LocalDateTime.now())
-        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
-        .build();
+    Integer page = 0;
+    Integer size = 20;
 
     List<Post> posts = Arrays.asList(post1, post2);
-    given(postController.findAllInLatestOrder()).willReturn(OK(posts));
+    given(postController.findAllInLatestOrder(page, size)).willReturn(OK(posts));
+
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.add("page", page.toString());
+    map.add("size", size.toString());
 
     //when
-    ResultActions result = mockMvc.perform(get("/posts")
-        .contentType(MediaType.APPLICATION_JSON));
+    ResultActions result = mockMvc.perform(get("/posts/createdAt")
+        .contentType(MediaType.APPLICATION_JSON)
+        .queryParams(map));
 
     //then
     result.andExpect(status().isOk())
@@ -136,12 +153,18 @@ class PostControllerTest {
         .andDo(document("{class-name}/{method-name}",
             getDocumentRequest(),
             getDocumentResponse(),
+            requestParameters(
+                parameterWithName("page").description("페이지 넘버"),
+                parameterWithName("size").description("페이지 당 보여줄 포스트 수")
+            ),
+
             responseFields(
                 fieldWithPath("success").description("성공 여부").type(JsonFieldType.BOOLEAN),
                 fieldWithPath("error").description("에러 메세지").type(JsonFieldType.NULL),
                 subsectionWithPath("response").description("응답"),
                 fieldWithPath("response.[].id").description("포스트 ID 번호(고유한 값)").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.[].title").description("포스트 제목").type(JsonFieldType.STRING),
+                fieldWithPath("response.[].subTitle").description("포스트 보조 제목").type(JsonFieldType.STRING),
                 fieldWithPath("response.[].content").description("포스트 내용").type(JsonFieldType.STRING),
                 fieldWithPath("response.[].thumbnail").description("포스트 썸네일").type(JsonFieldType.STRING),
                 fieldWithPath("response.[].author").description("포스트 저자").type(JsonFieldType.OBJECT),
@@ -152,22 +175,74 @@ class PostControllerTest {
             )));
   }
 
+  @DisplayName("메인 페이지 조회 (좋아요 순으로 내림차순 정렬)")
+  @Test
+  public void find_all_by_likes_in_descending_order() throws Exception {
+    //given
+    Post post1 = getPost(random, won, 1L, "1번째 포스팅 입니다");
+    Post post2 = getPost(random, won, 2L, "2번째 포스팅 입니다");
+    Post post3 = getPost(random, won, 3L, "3번째 포스팅 입니다");
+
+    Integer page = 0;
+    Integer size = 20;
+
+    List<Post> posts = Arrays.asList(post3, post2, post1);
+    given(postController.findAllByLikesInDescendingOrder(page, size)).willReturn(OK(posts));
+
+    //when
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.add("page", page.toString());
+    map.add("size", size.toString());
+
+    ResultActions result = mockMvc.perform(get("/posts/likes")
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .queryParams(map));
+
+    //then
+    result.andExpect(status().isOk())
+        .andDo(print())
+        .andDo(document("{class-name}/{method-name}",
+            getDocumentRequest(),
+            getDocumentResponse(),
+            requestParameters(
+                parameterWithName("page").description("페이지 넘버"),
+                parameterWithName("size").description("페이지 당 보여줄 포스트 수")
+            ),
+            responseFields(
+                fieldWithPath("success").description("성공 여부").type(JsonFieldType.BOOLEAN),
+                fieldWithPath("error").description("에러 메세지").type(JsonFieldType.NULL),
+
+                subsectionWithPath("response").description("응답"),
+
+                fieldWithPath("response.[].id").description("포스트 ID 번호(고유한 값)")
+                    .type(JsonFieldType.NUMBER),
+                fieldWithPath("response.[].title").description("포스트 제목").type(JsonFieldType.STRING),
+                fieldWithPath("response.[].subTitle").description("포스트 보조 제목")
+                    .type(JsonFieldType.STRING),
+                fieldWithPath("response.[].content").description("포스트 내용")
+                    .type(JsonFieldType.STRING),
+                fieldWithPath("response.[].thumbnail").description("포스트 썸네일")
+                    .type(JsonFieldType.STRING),
+                fieldWithPath("response.[].author").description("포스트 저자")
+                    .type(JsonFieldType.OBJECT),
+                fieldWithPath("response.[].views").description("포스트 조회").type(JsonFieldType.NUMBER),
+                fieldWithPath("response.[].likes").description("포스트 좋아요 수")
+                    .type(JsonFieldType.NUMBER),
+                fieldWithPath("response.[].tags").description("포스트 태그").type(JsonFieldType.STRING),
+                fieldWithPath("response.[].createdAt").description("포스트 생성 시간")
+                    .type(JsonFieldType.STRING)
+            )));
+  }
+
   @DisplayName("포스트 생성")
   @Test
   void create_post() throws Exception {
     //given
-    PostCreateRequest postCreateRequest = PostCreateRequest.builder()
-        .title("1번째 포스팅 입니다")
-        .content("이런 저런 내용이 담겨있어요")
-        .authorId(1L)
-        .tags("1번")
-        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
-        .build();
+    PostCreateRequest postCreateRequest = getPostCreateRequest();
 
     PostCreateResponse response = new PostCreateResponse();
     response.setPostId(1L);
-    log.debug("response : {}", response);
-    log.debug("create : {}", postCreateRequest);
     given(postController.create(any())).willReturn(OK(response));
 
     //when
@@ -185,11 +260,13 @@ class PostControllerTest {
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestFields(
-                    fieldWithPath("title").description("포스트 제목").type(JsonFieldType.STRING),
+                    fieldWithPath("title").description("포스트 제목부 (필수)").type(JsonFieldType.STRING),
+                    fieldWithPath("subTitle").description("포스트 제목 (필수)").type(JsonFieldType.STRING),
                     fieldWithPath("content").description("포스트 내용").type(JsonFieldType.STRING),
                     fieldWithPath("thumbnail").description("포스트 썸네일 이미지").type(JsonFieldType.STRING),
-                    fieldWithPath("authorId").description("포스트 작성자 ID").type(JsonFieldType.NUMBER),
-                    fieldWithPath("tags").description("포스트 태그").type(JsonFieldType.STRING)
+                    fieldWithPath("authorId").description("포스트 작성자 ID (필수)").type(JsonFieldType.NUMBER),
+                    fieldWithPath("tags").description("포스트 태그").type(JsonFieldType.STRING),
+                    fieldWithPath("isPublic").description("포스트 공개 여부 (필수)").type(JsonFieldType.BOOLEAN)
                 ),
                 responseFields(
                     fieldWithPath("success").description("성공 유무").type(JsonFieldType.BOOLEAN),
@@ -234,25 +311,7 @@ class PostControllerTest {
   void find_post_by_id() throws Exception {
 
     //given
-    Random random = new Random();
-
-    Account won = Account.builder()
-        .id(1L)
-        .name("won")
-        .avatarUrl("https://img.hankyung.com/photo/201906/03.19979855.1.jpg")
-        .build();
-
-    Post post = Post.builder()
-        .id(1L)
-        .title("1번째 포스팅 입니다")
-        .content("이런 저런 내용이 담겨있어요")
-        .author(won)
-        .likes(random.nextInt(99))
-        .tags("1번")
-        .views(random.nextInt(999))
-        .createdAt(LocalDateTime.now())
-        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
-        .build();
+    Post post = getPost(random, won, 1L, "1번째 포스팅 입니다");
 
     given(postController.findById(1L)).willReturn(OK(post));
 
@@ -279,100 +338,10 @@ class PostControllerTest {
                 fieldWithPath("response.content").description("포스트 내용").type(JsonFieldType.STRING),
                 fieldWithPath("response.thumbnail").description("포스트 썸네일").type(JsonFieldType.STRING),
                 fieldWithPath("response.author").description("포스트 저자").type(JsonFieldType.OBJECT),
-                fieldWithPath("response.views").description("포스트 조회").type(JsonFieldType.NUMBER), fieldWithPath("response.likes").description("포스트 좋아요 수").type(JsonFieldType.NUMBER),
+                fieldWithPath("response.views").description("포스트 조회").type(JsonFieldType.NUMBER),
+                fieldWithPath("response.likes").description("포스트 좋아요 수").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.tags").description("포스트 태그").type(JsonFieldType.STRING),
                 fieldWithPath("response.createdAt").description("포스트 생성 시간").type(JsonFieldType.STRING)
-            )));
-  }
-
-  @DisplayName("메인 페이지 조회 (좋아요 순으로 내름차순 정렬)")
-  @Test
-  public void find_all_by_likes_in_descending_order() throws Exception {
-    //given
-    Random random = new Random();
-
-    Account won = Account.builder()
-        .id(1L)
-        .name("won")
-        .avatarUrl("https://img.hankyung.com/photo/201906/03.19979855.1.jpg")
-        .build();
-
-    Post post1 = Post.builder()
-        .id(1L)
-        .title("1번째 포스팅 입니다")
-        .content("이런 저런 내용이 담겨있어요")
-        .author(won)
-        .likes(15)
-        .tags("1번")
-        .views(random.nextInt(999))
-        .createdAt(LocalDateTime.now())
-        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
-        .build();
-
-    Post post2 = Post.builder()
-        .id(2L)
-        .title("2번째 포스팅 입니다")
-        .content("이런 저런 내용이 담겨있어요")
-        .author(won)
-        .likes(20)
-        .tags("2번")
-        .views(random.nextInt(999))
-        .createdAt(LocalDateTime.now())
-        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
-        .build();
-
-    Post post3 = Post.builder()
-        .id(2L)
-        .title("2번째 포스팅 입니다")
-        .content("이런 저런 내용이 담겨있어요")
-        .author(won)
-        .likes(30)
-        .tags("2번")
-        .views(random.nextInt(999))
-        .createdAt(LocalDateTime.now())
-        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
-        .build();
-
-    Integer page = 0;
-    Integer size = 20;
-
-    List<Post> posts = Arrays.asList(post3, post2, post1);
-    log.info("posts : {}", posts);
-    given(postController.findAllByLikesInDescendingOrder(page, size)).willReturn(OK(posts));
-
-    //when
-    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-    map.add("page", page.toString());
-    map.add("size", size.toString());
-
-    ResultActions result = this.mockMvc.perform(get("/posts/likes")
-        .contentType(MediaType.APPLICATION_JSON)
-        .accept(MediaType.APPLICATION_JSON)
-        .queryParams(map));
-
-    //then
-    result.andExpect(status().isOk())
-        .andDo(print())
-        .andDo(document("{class-name}/{method-name}",
-            getDocumentRequest(),
-            getDocumentResponse(),
-            requestParameters(
-                parameterWithName("page").description("페이지 넘버"),
-                parameterWithName("size").description("페이지 당 보여줄 포스트 수")
-            ),
-            responseFields(
-                fieldWithPath("success").description("성공 여부").type(JsonFieldType.BOOLEAN),
-                fieldWithPath("error").description("에러 여부(발생 시, 어떠한 에러인지 기재)").type(JsonFieldType.NULL),
-                subsectionWithPath("response").description("응답"),
-                fieldWithPath("response.[].id").description("포스트 ID 번호(고유한 값)").type(JsonFieldType.NUMBER),
-                fieldWithPath("response.[].title").description("포스트 제목").type(JsonFieldType.STRING),
-                fieldWithPath("response.[].content").description("포스트 내용").type(JsonFieldType.STRING),
-                fieldWithPath("response.[].thumbnail").description("포스트 썸네일").type(JsonFieldType.STRING),
-                fieldWithPath("response.[].author").description("포스트 저자").type(JsonFieldType.OBJECT),
-                fieldWithPath("response.[].views").description("포스트 조회").type(JsonFieldType.NUMBER),
-                fieldWithPath("response.[].likes").description("포스트 좋아요 수").type(JsonFieldType.NUMBER),
-                fieldWithPath("response.[].tags").description("포스트 태그").type(JsonFieldType.STRING),
-                fieldWithPath("response.[].createdAt").description("포스트 생성 시간").type(JsonFieldType.STRING)
             )));
   }
 }

--- a/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
+++ b/src/test/java/com/codesquad/rare/domain/post/PostControllerTest.java
@@ -163,8 +163,7 @@ class PostControllerTest {
                 fieldWithPath("response.[].views").description("포스트 조회").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.[].likes").description("포스트 좋아요 수").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.[].tags").description("포스트 태그").type(JsonFieldType.STRING),
-                fieldWithPath("response.[].createdAt").description("포스트 생성 시간")
-                    .type(JsonFieldType.STRING)
+                fieldWithPath("response.[].createdAt").description("포스트 생성 시간").type(JsonFieldType.STRING)
             )));
   }
 
@@ -201,9 +200,7 @@ class PostControllerTest {
             responseFields(
                 fieldWithPath("success").description("성공 여부").type(JsonFieldType.BOOLEAN),
                 fieldWithPath("error").description("에러 메세지").type(JsonFieldType.NULL),
-
                 subsectionWithPath("response").description("응답"),
-
                 fieldWithPath("response.[].id").description("포스트 ID 번호(고유한 값)").type(JsonFieldType.NUMBER),
                 fieldWithPath("response.[].title").description("포스트 제목").type(JsonFieldType.STRING),
                 fieldWithPath("response.[].subTitle").description("포스트 보조 제목").type(JsonFieldType.STRING),
@@ -242,8 +239,8 @@ class PostControllerTest {
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestFields(
-                    fieldWithPath("title").description("포스트 제목부 (필수)").type(JsonFieldType.STRING),
-                    fieldWithPath("subTitle").description("포스트 제목 (필수)").type(JsonFieldType.STRING),
+                    fieldWithPath("title").description("포스트 제목 (필수)").type(JsonFieldType.STRING),
+                    fieldWithPath("subTitle").description("포스트 보조 제목 (필수)").type(JsonFieldType.STRING),
                     fieldWithPath("content").description("포스트 내용").type(JsonFieldType.STRING),
                     fieldWithPath("thumbnail").description("포스트 썸네일 이미지")
                         .type(JsonFieldType.STRING),
@@ -322,6 +319,7 @@ class PostControllerTest {
                 fieldWithPath("response.id").description("포스트 ID 번호(고유한 값)")
                     .type(JsonFieldType.NUMBER),
                 fieldWithPath("response.title").description("포스트 제목").type(JsonFieldType.STRING),
+                fieldWithPath("response.subTitle").description("포스트 보조 제목").type(JsonFieldType.STRING),
                 fieldWithPath("response.content").description("포스트 내용").type(JsonFieldType.STRING),
                 fieldWithPath("response.thumbnail").description("포스트 썸네일")
                     .type(JsonFieldType.STRING),

--- a/src/test/java/com/codesquad/rare/domain/post/PostServiceTest.java
+++ b/src/test/java/com/codesquad/rare/domain/post/PostServiceTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 class PostServiceTest {
 
-  private final Logger log = LoggerFactory.getLogger(PostServiceTest.class);
+  final Logger log = LoggerFactory.getLogger(PostServiceTest.class);
 
   @MockBean
   private PostRepository postRepository;
@@ -40,10 +40,12 @@ class PostServiceTest {
     Post post = Post.builder()
         .id(postId)
         .title("블로그 포스팅 테스트1")
+        .subTitle("보조 제목")
         .content("블로그에 글을 적는 건 즐거워")
         .thumbnail("thumbnail 이미지")
         .author(won)
         .tags("hamill")
+        .isPublic(Boolean.TRUE)
         .build();
 
     given(postRepository.save(post)).willReturn(post);

--- a/src/test/java/com/codesquad/rare/domain/post/request/PostCreateRequestTest.java
+++ b/src/test/java/com/codesquad/rare/domain/post/request/PostCreateRequestTest.java
@@ -1,0 +1,66 @@
+package com.codesquad.rare.domain.post.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class PostCreateRequestTest {
+
+  final Logger log = LoggerFactory.getLogger(PostCreateRequestTest.class);
+
+  Validator validator;
+
+  @BeforeEach
+  void setValidator() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @DisplayName("isPublic이 Null이면 오류를 반환한다.")
+  @Test
+  void isPublic_should_NotNull() {
+    //given
+    PostCreateRequest request = PostCreateRequest.builder()
+        .title("타이틀입니다일 (필수)")
+        .subTitle("보조 타이틀 입니다(필수)")
+        .content("내용")
+        .authorId(1L)
+        .tags("1번")
+        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
+        .isPublic(null)
+        .build();
+
+    //when
+    Set<ConstraintViolation<PostCreateRequest>> violations = validator.validate(request);
+    log.debug(violations.iterator().next().getMessage());
+
+    //then
+    assertThat(violations.size()).isEqualTo(1);
+  }
+
+  @DisplayName("title, subTitle 이 없을 경우 오류를 반환한다")
+  @Test
+  void title_should_NotNull() {
+    //given
+    PostCreateRequest request = PostCreateRequest.builder()
+        .content("내용")
+        .authorId(1L)
+        .tags("1번")
+        .thumbnail("https://i.ytimg.com/vi/FN506P8rX4s/maxresdefault.jpg")
+        .isPublic(true)
+        .build();
+
+    //when
+    Set<ConstraintViolation<PostCreateRequest>> violations = validator.validate(request);
+
+    //then
+    assertThat(violations.size()).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
Resolved #58 

### 구현 설명
- front 요청에 따른 PostCreateRequest 생성에 필요한 멤버 변수 추가
- Test 작성 및 수정
- 메인 페이지 2 기능 구현 (페이징, 공개된 포스팅만 조회되도록)
  - 향 후 이 건 하나의 메서드에서 처리하도록 해야할듯
- 메인페이지에 필요한 PostResponse, 포스트 조회에서 필요한 PostResponse 구현이 필요할듯